### PR TITLE
Move buttons to bottom of the page and rename interface names for ifstats

### DIFF
--- a/src/assets/includes/chart.php
+++ b/src/assets/includes/chart.php
@@ -23,7 +23,7 @@ var dataPoints4 = <?php echo json_encode($dataPointsIni, JSON_NUMERIC_CHECK); ?>
 var chart = new CanvasJS.Chart("chartContainerBenign", {
   zoomEnabled: true,
   title: {
-    text: "Inside Interface Network Traffic"
+    text: "Port 1 Network Traffic"
   },
   axisX: {
     title: "chart updates every " + updateInterval / 1000 + " secs"
@@ -76,7 +76,7 @@ var chart = new CanvasJS.Chart("chartContainerBenign", {
 var chart2 = new CanvasJS.Chart("chartContainerMalicious", {
   zoomEnabled: true,
   title: {
-    text: "Outside Interface Network Traffic"
+    text: "Port 2 Network Traffic"
   },
   axisX: {
     title: "chart updates every " + updateInterval / 1000 + " secs"

--- a/src/selected-tool.php
+++ b/src/selected-tool.php
@@ -131,10 +131,6 @@
                     <input id='target' type="text" placeholder="Example: 127.0.0.1" class="form-control is-valid" />
                   </div>
                 </div>
-                <button class="btn btn-success" type="button" data-toggle="collapse" data-target="#options"> + Options</button>
-                <button class="btn btn-default" type="button" onclick="execute();"><i class="ni ni-bold-right"></i> Execute</button>
-                <button class="btn btn-info" type="button" onclick="add_bulk_exec();"><i class="ni ni-archive-2"></i> Add for bulk exec later</button>
-                <br><br>
                 <div class="collapse options" id="options">
                   <h6 class="heading-small text-muted mb-4">Inputs</h6>
                   <!-- INPUTS LIST COMMANDS -->
@@ -258,6 +254,9 @@
                   </div>
 
                 </div>
+                <button class="btn btn-success" type="button" data-toggle="collapse" data-target="#options"> + Options</button>
+                <button class="btn btn-default" type="button" onclick="execute();"><i class="ni ni-bold-right"></i> Execute</button>
+                <button class="btn btn-info" type="button" onclick="add_bulk_exec();"><i class="ni ni-archive-2"></i> Add for bulk exec later</button>
               </form>
               <?php include ("assets/includes/list-commands.php"); ?>  
             </div>


### PR DESCRIPTION
This pull request changes the placement of exec buttons on the Tools > Execute page. Additionally, we also renamed the interface names on the dashboard web home (interface statistics).