### PR TITLE
Set format output area as monospace

### DIFF
--- a/src/assets/css/argon.css
+++ b/src/assets/css/argon.css
@@ -399,6 +399,8 @@ textarea
     overflow: auto;
 
     resize: vertical;
+
+    font-family: monospace;
 }
 
 fieldset


### PR DESCRIPTION
Closes #58

Before:

![image](https://github.com/user-attachments/assets/68edaec0-b7c9-427a-b044-69d301bfbb5f)

Now:

![image](https://github.com/user-attachments/assets/1bbb1d2c-b57a-4e32-bb5f-92311707c704)
