### PR TITLE
Dynamic load Analytics measurement scripts and js

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,9 @@ cp /var/lib/shellinabox/.ssh/id_rsa.pub /root/.ssh/authorized_keys
 # force SSL cert to be recreated
 make-ssl-cert --force-overwrite generate-default-snakeoil
 
+# Export Environment Vars
+echo "SetEnv GTAG \"${GTAG}\"" >> /etc/apache2/conf-enabled/environment.conf
+
 # start services
 service ssh start
 service apache2 start

--- a/src/assets/includes/footer.php
+++ b/src/assets/includes/footer.php
@@ -16,12 +16,9 @@
 <script src="assets/js/canvasjs.min.js"></script>
 <!-- Analytics measurements -->
 <?php
-$jsfile = getenv("ANALYTICS_JSFILE");
-if ($jsfile) {
-   echo "<script async src='$jsfile'></script>\n";
-}
-$script = getenv("ANALYTICS_SCRIPT");
-if ($script) {
-   echo "<script>\n$script\n</script>\n";
+$gtag = getenv("GTAG");
+if ($gtag) {
+   echo "<script async src='https://www.googletagmanager.com/gtag/js?id=$gtag'></script>\n";
+   echo "<script>\nwindow.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);};gtag('js',new Date());gtag('config', '$gtag');\n</script>\n";
 }
 ?>

--- a/src/assets/includes/footer.php
+++ b/src/assets/includes/footer.php
@@ -14,3 +14,14 @@
 <script src="assets/js/bootstrap.bundle.min.js"></script>
 <script src="assets/js/argon.js?v=1.0.0"></script>
 <script src="assets/js/canvasjs.min.js"></script>
+<!-- Analytics measurements -->
+<?php
+$jsfile = getenv("ANALYTICS_JSFILE");
+if ($jsfile) {
+   echo "<script async src='$jsfile'></script>\n";
+}
+$script = getenv("ANALYTICS_SCRIPT");
+if ($script) {
+   echo "<script>\n$script\n</script>\n";
+}
+?>


### PR DESCRIPTION
Fix #62 

### Description of the change

This PR adds the capability of dynamically loading javascript files and inline javascript code in order to enable Analytics Measurements. I decided to keep this measurement specific for Google Analytics (GTAG) for now, to avoid any risk of code injection on the application based on the environment var. So, in order to enable Google Analytics measurement you just need to define the env var `GTAG` with the tag you get from google tag manager.
